### PR TITLE
chore: upgrade Semantic Kernel to 1.0.0-beta1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <!--Unit Test-->
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.0.0-beta1" />
+    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.0.0-beta2" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.6.11" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="System.Text.Json" Version="6.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <!--Unit Test-->
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel" Version="0.21.230828.2-preview" />
+    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.0.0-beta1" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.6.11" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="System.Text.Json" Version="6.0.8" />

--- a/samples/DashScope.Sample.Console/Program.cs
+++ b/samples/DashScope.Sample.Console/Program.cs
@@ -38,7 +38,7 @@ while (true)
              }
         }
     });
-    
+
     if (result.IsTextResponse)
     {
         Console.WriteLine(result.Output.Text);

--- a/samples/DashScope.Sample.Console/Program.cs
+++ b/samples/DashScope.Sample.Console/Program.cs
@@ -38,5 +38,13 @@ while (true)
              }
         }
     });
-    Console.WriteLine(result.Output.Text);
+    
+    if (result.IsTextResponse)
+    {
+        Console.WriteLine(result.Output.Text);
+    }
+    else
+    {
+        Console.WriteLine(result.Output.Choices![0].Message.Content);
+    }
 }

--- a/samples/SK-DashScope.Sample/Controllers/ApiController.cs
+++ b/samples/SK-DashScope.Sample/Controllers/ApiController.cs
@@ -131,6 +131,7 @@ namespace SK_DashScope.Sample.Controllers
             var text = await result.First().GetCompletionAsync(cancellationToken);
             return Ok(text);
         }
+        
         [HttpPost("text_stream_with_settings")]
         public async Task TextStreamWithDashScopeSettingsAsync([FromBody] UserInput input, CancellationToken cancellationToken)
         {
@@ -159,6 +160,31 @@ namespace SK_DashScope.Sample.Controllers
             }
 
             await Response.CompleteAsync();
+        }
+        
+        [HttpPost("text_with_message_format")]
+        public async Task<IActionResult> TextWithMessageFormatAsync([FromBody] UserInput input, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(input.Text))
+            {
+                return NoContent();
+            }
+
+            var completion = kernel.GetService<ITextCompletion>();
+            var settings = new DashScopeAIRequestSettings()
+            {
+                TopP = 0.5f,
+                TopK = 0,
+                Seed = 1234,
+                Temperature = 0.5f,
+                IncrementalOutput = false,
+                EnableSearch = true,
+                ResultFormat = "message"
+            };
+            var result = await completion.GetCompletionsAsync(input.Text, settings, cancellationToken);
+
+            var text = await result[0].GetCompletionAsync(cancellationToken);
+            return Ok(text);
         }
     }
 }

--- a/samples/SK-DashScope.Sample/Controllers/ApiController.cs
+++ b/samples/SK-DashScope.Sample/Controllers/ApiController.cs
@@ -73,12 +73,8 @@ namespace SK_DashScope.Sample.Controllers
             var chat = kernel.GetService<IChatCompletion>();
             var history = chat.CreateNewChat();
             history.AddUserMessage(input.Text);
-            
-            // 可以使用IncrementalOutput来控制stream输出的方式
-            var settings = new DashScopeAIRequestSettings()
-            {
-                IncrementalOutput = true
-            };
+
+            var settings = new DashScopeAIRequestSettings();
             var results = chat.GenerateMessageStreamAsync(history, settings, cancellationToken: cancellationToken);
 
             await foreach (var result in results)
@@ -106,7 +102,7 @@ namespace SK_DashScope.Sample.Controllers
 
             return Ok(serializableList);
         }
-        
+
         [HttpPost("text_with_settings")]
         public async Task<IActionResult> TextWithDashScopeSettingsAsync([FromBody] UserInput input, CancellationToken cancellationToken)
         {
@@ -122,16 +118,14 @@ namespace SK_DashScope.Sample.Controllers
                 TopK = 10,
                 Seed = 1234,
                 Temperature = 0.5f,
-                IncrementalOutput = false,
                 EnableSearch = true,
-                ResultFormat = "text"
             };
             var result = await completion.GetCompletionsAsync(input.Text, settings, cancellationToken);
 
             var text = await result.First().GetCompletionAsync(cancellationToken);
             return Ok(text);
         }
-        
+
         [HttpPost("text_stream_with_settings")]
         public async Task TextStreamWithDashScopeSettingsAsync([FromBody] UserInput input, CancellationToken cancellationToken)
         {
@@ -141,14 +135,10 @@ namespace SK_DashScope.Sample.Controllers
             }
 
             var completion = kernel.GetService<ITextCompletion>();
-            
-            // 可以使用IncrementalOutput来控制stream输出的方式
-            var settings = new DashScopeAIRequestSettings()
-            {
-                IncrementalOutput = true
-            };
+
+            var settings = new DashScopeAIRequestSettings();
             var streamingResults = completion.GetStreamingCompletionsAsync(input.Text, settings, cancellationToken: cancellationToken);
-            
+
             await foreach (var streamingResult in streamingResults)
             {
                 var results = streamingResult.GetCompletionStreamingAsync(cancellationToken);
@@ -160,31 +150,6 @@ namespace SK_DashScope.Sample.Controllers
             }
 
             await Response.CompleteAsync();
-        }
-        
-        [HttpPost("text_with_message_format")]
-        public async Task<IActionResult> TextWithMessageFormatAsync([FromBody] UserInput input, CancellationToken cancellationToken)
-        {
-            if (string.IsNullOrWhiteSpace(input.Text))
-            {
-                return NoContent();
-            }
-
-            var completion = kernel.GetService<ITextCompletion>();
-            var settings = new DashScopeAIRequestSettings()
-            {
-                TopP = 0.5f,
-                TopK = 0,
-                Seed = 1234,
-                Temperature = 0.5f,
-                IncrementalOutput = false,
-                EnableSearch = true,
-                ResultFormat = "message"
-            };
-            var result = await completion.GetCompletionsAsync(input.Text, settings, cancellationToken);
-
-            var text = await result[0].GetCompletionAsync(cancellationToken);
-            return Ok(text);
         }
     }
 }

--- a/samples/SK-DashScope.Sample/Controllers/ApiController.cs
+++ b/samples/SK-DashScope.Sample/Controllers/ApiController.cs
@@ -5,6 +5,7 @@ using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using SK_DashScope.Sample.Models;
 using System.Text;
+using DashScope.SemanticKernel;
 using Microsoft.SemanticKernel.AI;
 
 namespace SK_DashScope.Sample.Controllers
@@ -47,6 +48,7 @@ namespace SK_DashScope.Sample.Controllers
             var completion = kernel.GetService<ITextCompletion>();
             // CompleteRequestSettings 已经被弃用且删除，新版改用 AIRequestSettings
             // 自定义参数在属性ExtensionData里
+            // 或者使用 DashScopeAIRequestSettings，用法请看下面的函数 TextWithDashScopeSettingsAsync
             var settings = new AIRequestSettings
             {
                 ExtensionData = new Dictionary<string, object>
@@ -71,8 +73,13 @@ namespace SK_DashScope.Sample.Controllers
             var chat = kernel.GetService<IChatCompletion>();
             var history = chat.CreateNewChat();
             history.AddUserMessage(input.Text);
-
-            var results = chat.GenerateMessageStreamAsync(history, cancellationToken: cancellationToken);
+            
+            // 可以使用IncrementalOutput来控制stream输出的方式
+            var settings = new DashScopeAIRequestSettings()
+            {
+                IncrementalOutput = true
+            };
+            var results = chat.GenerateMessageStreamAsync(history, settings, cancellationToken: cancellationToken);
 
             await foreach (var result in results)
             {
@@ -98,6 +105,31 @@ namespace SK_DashScope.Sample.Controllers
             var serializableList = result.ToArray().ToList();
 
             return Ok(serializableList);
+        }
+        
+        [HttpPost("text_with_settings")]
+        public async Task<IActionResult> TextWithDashScopeSettingsAsync([FromBody] UserInput input, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(input.Text))
+            {
+                return NoContent();
+            }
+
+            var completion = kernel.GetService<ITextCompletion>();
+            var settings = new DashScopeAIRequestSettings()
+            {
+                TopP = 0.5f,
+                TopK = 10,
+                Seed = 1234,
+                Temperature = 0.5f,
+                IncrementalOutput = false,
+                EnableSearch = true,
+                ResultFormat = "text"
+            };
+            var result = await completion.GetCompletionsAsync(input.Text, settings, cancellationToken);
+
+            var text = await result.First().GetCompletionAsync(cancellationToken);
+            return Ok(text);
         }
     }
 }

--- a/samples/SK-DashScope.Sample/Controllers/ApiController.cs
+++ b/samples/SK-DashScope.Sample/Controllers/ApiController.cs
@@ -5,6 +5,7 @@ using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticKernel.AI.TextCompletion;
 using SK_DashScope.Sample.Models;
 using System.Text;
+using Microsoft.SemanticKernel.AI;
 
 namespace SK_DashScope.Sample.Controllers
 {
@@ -44,7 +45,17 @@ namespace SK_DashScope.Sample.Controllers
             }
 
             var completion = kernel.GetService<ITextCompletion>();
-            var result = await completion.GetCompletionsAsync(input.Text, new CompleteRequestSettings { TopP = 0.8 }, cancellationToken);
+            // CompleteRequestSettings 已经被弃用且删除，新版改用 AIRequestSettings
+            // 自定义参数在属性ExtensionData里
+            var settings = new AIRequestSettings
+            {
+                ExtensionData = new Dictionary<string, object>
+                {
+                    { "top_p", 0.8 }
+                }
+            };
+            var result = await completion.GetCompletionsAsync(input.Text, settings, cancellationToken);
+
             var text = await result.First().GetCompletionAsync();
             return Ok(text);
         }

--- a/samples/SK-DashScope.Sample/Program.cs
+++ b/samples/SK-DashScope.Sample/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Plugins.Memory;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,9 +15,15 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddScoped(svc =>
 {
     var kernel = Kernel.Builder.WithDashScopeCompletionService(builder.Configuration["DashScope:ApiKey"])
-    .WithDashScopeTextEmbeddingGenerationService(builder.Configuration["DashScope:ApiKey"])
     .Build();
     return kernel;
+});
+
+builder.Services.AddScoped(svc =>
+{
+    return new MemoryBuilder()
+    .WithDashScopeTextEmbeddingGenerationService(builder.Configuration["DashScope:ApiKey"])
+    .Build();
 });
 
 var app = builder.Build();

--- a/src/DashScope.SemanticKernel/DashScopeAIRequestSettings.cs
+++ b/src/DashScope.SemanticKernel/DashScopeAIRequestSettings.cs
@@ -1,0 +1,47 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.SemanticKernel.AI;
+
+namespace DashScope.SemanticKernel;
+
+public class DashScopeAIRequestSettings : AIRequestSettings
+{
+    [JsonPropertyName("temperature")]
+    public float? Temperature { get; set; }
+
+    [JsonPropertyName("top_p")]
+    public float? TopP { get; set; }
+    
+    private static readonly JsonSerializerOptions s_options = new()
+    {
+        WriteIndented = true,
+        MaxDepth = 20,
+        AllowTrailingCommas = true,
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip
+    };
+    
+    public static DashScopeAIRequestSettings FromRequestSettings(AIRequestSettings? requestSettings, int? defaultMaxTokens = null)
+    {
+        if (requestSettings is null)
+        {
+            return new DashScopeAIRequestSettings();
+        }
+
+        if (requestSettings is DashScopeAIRequestSettings requestSettingDashScopeAIRequestSettings)
+        {
+            return requestSettingDashScopeAIRequestSettings;
+        }
+
+        var json = JsonSerializer.Serialize(requestSettings);
+        var dashScopeAIRequestSettings = JsonSerializer.Deserialize<DashScopeAIRequestSettings>(json, s_options);
+
+        if (dashScopeAIRequestSettings is not null)
+        {
+            return dashScopeAIRequestSettings;
+        }
+
+        throw new ArgumentException($"Invalid request settings, cannot convert to {nameof(DashScopeAIRequestSettings)}", nameof(requestSettings));
+    }
+    
+}

--- a/src/DashScope.SemanticKernel/DashScopeAIRequestSettings.cs
+++ b/src/DashScope.SemanticKernel/DashScopeAIRequestSettings.cs
@@ -5,73 +5,42 @@ using Microsoft.SemanticKernel.AI;
 namespace DashScope.SemanticKernel;
 
 /// <summary>
-/// 支持自定的参数有
-/// <code>
-/// TopP
-/// TopK
-/// Seed
-/// Temperature
-/// IncrementalOutput
-/// EnableSearch
-/// ResultFormat
+/// DashScope的配置参数
 /// </code>
 /// </summary>
 public class DashScopeAIRequestSettings : AIRequestSettings
 {
-        /// <summary>
-        /// 生成时，核采样方法的概率阈值。例如，取值为0.5时，仅保留累计概率之和大于等于0.5的概率分布中的token，作为随机采样的候选集。取值范围为(0,1.0)，取值越大，生成的随机性越高；取值越低，生成的随机性越低。默认值 0.5。注意，取值不要大于等于1
-        /// </summary>
-        [JsonPropertyName("top_p")]
-        public float? TopP { get; set; } = 0.5f;
+    /// <summary>
+    /// 生成时，核采样方法的概率阈值。例如，取值为0.5时，仅保留累计概率之和大于等于0.5的概率分布中的token，作为随机采样的候选集。取值范围为(0,1.0)，取值越大，生成的随机性越高；取值越低，生成的随机性越低。默认值 0.5。注意，取值不要大于等于1
+    /// </summary>
+    [JsonPropertyName("top_p")]
+    public float? TopP { get; set; } = 0.5f;
 
-        /// <summary>
-        /// 默认值为null，表示不启用top_k策略，取值范围：[1, 100]，生成时，采样候选集的大小。例如，取值为50时，仅将单次生成中得分最高的50个token组成随机采样的候选集。取值越大，生成的随机性越高；取值越小，生成的确定性越高。注意：如果top_k的值大于100，则不会启用top_k策略，此时仅有top_p策略生效。
-        /// </summary>
-        [JsonPropertyName("top_k")]
-        public int? TopK { get; set; }
+    /// <summary>
+    /// 默认值为null，表示不启用top_k策略，取值范围：[1, 100]，生成时，采样候选集的大小。例如，取值为50时，仅将单次生成中得分最高的50个token组成随机采样的候选集。取值越大，生成的随机性越高；取值越小，生成的确定性越高。注意：如果top_k的值大于100，则不会启用top_k策略，此时仅有top_p策略生效。
+    /// </summary>
+    [JsonPropertyName("top_k")]
+    public int? TopK { get; set; }
 
-        /// <summary>
-        /// 生成时，随机数的种子，用于控制模型生成的随机性。如果使用相同的种子，每次运行生成的结果都将相同；当需要复现模型的生成结果时，可以使用相同的种子。seed参数支持无符号64位整数类型。默认值 1234
-        /// </summary>
-        [JsonPropertyName("seed")]
-        public long? Seed { get; set; } = 1234;
+    /// <summary>
+    /// 生成时，随机数的种子，用于控制模型生成的随机性。如果使用相同的种子，每次运行生成的结果都将相同；当需要复现模型的生成结果时，可以使用相同的种子。seed参数支持无符号64位整数类型。默认值 1234
+    /// </summary>
+    [JsonPropertyName("seed")]
+    public long? Seed { get; set; } = 1234;
 
-        /// <summary>
-        /// 生成时，是否参考夸克搜索的结果。注意：打开搜索并不意味着一定会使用搜索结果；如果打开搜索，模型会将搜索结果作为prompt，进而“自行判断”是否生成结合搜索结果的文本，默认为false
-        /// </summary>
-        [JsonPropertyName("enable_search")]
-        public bool? EnableSearch { get; set; } = false;
-        
-        /// <summary>
-        /// "text"表示旧版本的text，"message"表示兼容openai的message
-        /// </summary>
-        [JsonPropertyName("result_format")]
-        public string? ResultFormat { get; set; }
+    /// <summary>
+    /// 生成时，是否参考夸克搜索的结果。注意：打开搜索并不意味着一定会使用搜索结果；如果打开搜索，模型会将搜索结果作为prompt，进而“自行判断”是否生成结合搜索结果的文本，默认为false
+    /// </summary>
+    [JsonPropertyName("enable_search")]
+    public bool? EnableSearch { get; set; } = false;
 
-        /// <summary>
-        ///用于控制随机性和多样性的程度。具体来说，temperature值控制了生成文本时对每个候选词的概率分布进行平滑的程度。较高的temperature值会降低概率分布的峰值，使得更多的低概率词被选择，生成结果更加多样化；而较低的temperature值则会增强概率分布的峰值，使得高概率词更容易被选择，生成结果更加确定。取值范围： (0, 2),系统默认值1.0
-        /// </summary>
-        [JsonPropertyName("temperature")]
-        public float? Temperature { get; set; } = 1.0f;
+    /// <summary>
+    ///用于控制随机性和多样性的程度。具体来说，temperature值控制了生成文本时对每个候选词的概率分布进行平滑的程度。较高的temperature值会降低概率分布的峰值，使得更多的低概率词被选择，生成结果更加多样化；而较低的temperature值则会增强概率分布的峰值，使得高概率词更容易被选择，生成结果更加确定。取值范围： (0, 2),系统默认值1.0
+    /// </summary>
+    [JsonPropertyName("temperature")]
+    public float? Temperature { get; set; } = 1.0f;
 
-        /// <summary>
-        /// 控制流式输出模式，默认False，即后面内容会包含已经输出的内容；设置为True，将开启增量输出模式，后面输出不会包含已经输出的内容，您需要自行拼接整体输出
-        /// <example> 流式输出示例代码
-        /// <code>
-        /// 值为False时:
-        /// I
-        /// I like
-        /// I like apple
-        /// 值为True时:
-        /// I
-        /// like
-        /// apple
-        /// </code>
-        /// </example>
-        /// </summary>
-        [JsonPropertyName("incremental_output")]
-        public bool? IncrementalOutput { get; set; } = false;
-    
+
     private static readonly JsonSerializerOptions s_options = new()
     {
         WriteIndented = true,
@@ -80,7 +49,7 @@ public class DashScopeAIRequestSettings : AIRequestSettings
         PropertyNameCaseInsensitive = true,
         ReadCommentHandling = JsonCommentHandling.Skip
     };
-    
+
     public static DashScopeAIRequestSettings FromRequestSettings(AIRequestSettings? requestSettings, int? defaultMaxTokens = null)
     {
         if (requestSettings is null)
@@ -103,5 +72,5 @@ public class DashScopeAIRequestSettings : AIRequestSettings
 
         throw new ArgumentException($"Invalid request settings, cannot convert to {nameof(DashScopeAIRequestSettings)}", nameof(requestSettings));
     }
-    
+
 }

--- a/src/DashScope.SemanticKernel/DashScopeAIRequestSettings.cs
+++ b/src/DashScope.SemanticKernel/DashScopeAIRequestSettings.cs
@@ -4,13 +4,73 @@ using Microsoft.SemanticKernel.AI;
 
 namespace DashScope.SemanticKernel;
 
+/// <summary>
+/// 支持自定的参数有
+/// <code>
+/// TopP
+/// TopK
+/// Seed
+/// Temperature
+/// IncrementalOutput
+/// EnableSearch
+/// ResultFormat
+/// </code>
+/// </summary>
 public class DashScopeAIRequestSettings : AIRequestSettings
 {
-    [JsonPropertyName("temperature")]
-    public float? Temperature { get; set; }
+        /// <summary>
+        /// 生成时，核采样方法的概率阈值。例如，取值为0.5时，仅保留累计概率之和大于等于0.5的概率分布中的token，作为随机采样的候选集。取值范围为(0,1.0)，取值越大，生成的随机性越高；取值越低，生成的随机性越低。默认值 0.5。注意，取值不要大于等于1
+        /// </summary>
+        [JsonPropertyName("top_p")]
+        public float? TopP { get; set; } = 0.5f;
 
-    [JsonPropertyName("top_p")]
-    public float? TopP { get; set; }
+        /// <summary>
+        /// 默认值为null，表示不启用top_k策略，取值范围：[1, 100]，生成时，采样候选集的大小。例如，取值为50时，仅将单次生成中得分最高的50个token组成随机采样的候选集。取值越大，生成的随机性越高；取值越小，生成的确定性越高。注意：如果top_k的值大于100，则不会启用top_k策略，此时仅有top_p策略生效。
+        /// </summary>
+        [JsonPropertyName("top_k")]
+        public int? TopK { get; set; }
+
+        /// <summary>
+        /// 生成时，随机数的种子，用于控制模型生成的随机性。如果使用相同的种子，每次运行生成的结果都将相同；当需要复现模型的生成结果时，可以使用相同的种子。seed参数支持无符号64位整数类型。默认值 1234
+        /// </summary>
+        [JsonPropertyName("seed")]
+        public long? Seed { get; set; } = 1234;
+
+        /// <summary>
+        /// 生成时，是否参考夸克搜索的结果。注意：打开搜索并不意味着一定会使用搜索结果；如果打开搜索，模型会将搜索结果作为prompt，进而“自行判断”是否生成结合搜索结果的文本，默认为false
+        /// </summary>
+        [JsonPropertyName("enable_search")]
+        public bool? EnableSearch { get; set; } = false;
+        
+        /// <summary>
+        /// "text"表示旧版本的text，"message"表示兼容openai的message
+        /// </summary>
+        [JsonPropertyName("result_format")]
+        public string? ResultFormat { get; set; }
+
+        /// <summary>
+        ///用于控制随机性和多样性的程度。具体来说，temperature值控制了生成文本时对每个候选词的概率分布进行平滑的程度。较高的temperature值会降低概率分布的峰值，使得更多的低概率词被选择，生成结果更加多样化；而较低的temperature值则会增强概率分布的峰值，使得高概率词更容易被选择，生成结果更加确定。取值范围： (0, 2),系统默认值1.0
+        /// </summary>
+        [JsonPropertyName("temperature")]
+        public float? Temperature { get; set; } = 1.0f;
+
+        /// <summary>
+        /// 控制流式输出模式，默认False，即后面内容会包含已经输出的内容；设置为True，将开启增量输出模式，后面输出不会包含已经输出的内容，您需要自行拼接整体输出
+        /// <example> 流式输出示例代码
+        /// <code>
+        /// 值为False时:
+        /// I
+        /// I like
+        /// I like apple
+        /// 值为True时:
+        /// I
+        /// like
+        /// apple
+        /// </code>
+        /// </example>
+        /// </summary>
+        [JsonPropertyName("incremental_output")]
+        public bool? IncrementalOutput { get; set; } = false;
     
     private static readonly JsonSerializerOptions s_options = new()
     {
@@ -28,17 +88,17 @@ public class DashScopeAIRequestSettings : AIRequestSettings
             return new DashScopeAIRequestSettings();
         }
 
-        if (requestSettings is DashScopeAIRequestSettings requestSettingDashScopeAIRequestSettings)
+        if (requestSettings is DashScopeAIRequestSettings requestSettingDashScopeAiRequestSettings)
         {
-            return requestSettingDashScopeAIRequestSettings;
+            return requestSettingDashScopeAiRequestSettings;
         }
 
         var json = JsonSerializer.Serialize(requestSettings);
-        var dashScopeAIRequestSettings = JsonSerializer.Deserialize<DashScopeAIRequestSettings>(json, s_options);
+        var dashScopeAiRequestSettings = JsonSerializer.Deserialize<DashScopeAIRequestSettings>(json, s_options);
 
-        if (dashScopeAIRequestSettings is not null)
+        if (dashScopeAiRequestSettings is not null)
         {
-            return dashScopeAIRequestSettings;
+            return dashScopeAiRequestSettings;
         }
 
         throw new ArgumentException($"Invalid request settings, cannot convert to {nameof(DashScopeAIRequestSettings)}", nameof(requestSettings));

--- a/src/DashScope.SemanticKernel/DashScopeChatResult.cs
+++ b/src/DashScope.SemanticKernel/DashScopeChatResult.cs
@@ -32,42 +32,19 @@ namespace DashScope.SemanticKernel
 
         public Task<ChatMessageBase> GetChatMessageAsync(CancellationToken cancellationToken = default)
         {
-            if (_response!.IsTextResponse)
-            {
-                return Task.FromResult<ChatMessageBase>(new DashScopeChatMessage(AuthorRole.Assistant, _response!.Output.Text!));
-            }
-            else
-            {
-                Message message = _response!.Output.Choices![0].Message;
-                return Task.FromResult<ChatMessageBase>(new DashScopeChatMessage(AuthorRole.Assistant, message.Content));
-            }
+            return Task.FromResult<ChatMessageBase>(new DashScopeChatMessage(AuthorRole.Assistant, _response!.Output.Text!));
         }
 
         public Task<string> GetCompletionAsync(CancellationToken cancellationToken = default)
         {
-            if (_response!.IsTextResponse)
-            {
-                return Task.FromResult<string>(_response!.Output.Text!);
-            }
-            else
-            {
-                Message message = _response!.Output.Choices![0].Message;
-                return Task.FromResult<string>(message.Content);
-            }
+            return Task.FromResult<string>(_response!.Output.Text!);
         }
 
         public async IAsyncEnumerable<string> GetCompletionStreamingAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await foreach (var response in responses!)
             {
-                if (response.IsTextResponse)
-                {
-                    yield return response.Output.Text!;
-                }
-                else
-                {
-                    yield return response.Output.Choices![0].Message.Content;
-                }
+                yield return response.Output.Text!;
             }
         }
 
@@ -75,15 +52,7 @@ namespace DashScope.SemanticKernel
         {
             await foreach (var response in responses!)
             {
-                if (response.IsTextResponse)
-                { 
-                    yield return new DashScopeChatMessage(AuthorRole.Assistant, response.Output.Text!);
-                }
-                else
-                {
-                    Message message = response.Output.Choices![0].Message;
-                    yield return new DashScopeChatMessage(AuthorRole.Assistant, message.Content);
-                }
+                yield return new DashScopeChatMessage(AuthorRole.Assistant, response.Output.Text!);
             }
         }
 

--- a/src/DashScope.SemanticKernel/DashScopeEmbeddingGeneration.cs
+++ b/src/DashScope.SemanticKernel/DashScopeEmbeddingGeneration.cs
@@ -1,7 +1,7 @@
 ﻿using DashScope;
 using Microsoft;
-using Microsoft.SemanticKernel.AI;
 using Microsoft.SemanticKernel.AI.Embeddings;
+using Microsoft.SemanticKernel.Diagnostics;
 
 public class DashScopeEmbeddingGeneration : ITextEmbeddingGeneration
 {
@@ -35,7 +35,11 @@ public class DashScopeEmbeddingGeneration : ITextEmbeddingGeneration
         }
         catch (DashScopeException ex)
         {
-            throw new AIException(AIException.ErrorCodes.ServiceError, ex.Message, ex);
+            // 新版已弃用且删除 AIException
+            // 改用 SKException 和 HttpOperationException
+            // 详见 https://github.com/microsoft/semantic-kernel/issues/1669
+            // part8 与 part9
+            throw new SKException(ex.Message, ex);
         }
     }
 }

--- a/src/DashScope.SemanticKernel/DashScopeEmbeddingGeneration.cs
+++ b/src/DashScope.SemanticKernel/DashScopeEmbeddingGeneration.cs
@@ -35,10 +35,6 @@ public class DashScopeEmbeddingGeneration : ITextEmbeddingGeneration
         }
         catch (DashScopeException ex)
         {
-            // 新版已弃用且删除 AIException
-            // 改用 SKException 和 HttpOperationException
-            // 详见 https://github.com/microsoft/semantic-kernel/issues/1669
-            // part8 与 part9
             throw new SKException(ex.Message, ex);
         }
     }

--- a/src/DashScope.SemanticKernel/DashScopeKernelBuilderExtentions.cs
+++ b/src/DashScope.SemanticKernel/DashScopeKernelBuilderExtentions.cs
@@ -3,6 +3,7 @@ using DashScope.SemanticKernel;
 using Microsoft.SemanticKernel.AI.ChatCompletion;
 using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticKernel.AI.TextCompletion;
+using Microsoft.SemanticKernel.Plugins.Memory;
 
 namespace Microsoft.SemanticKernel
 {
@@ -18,7 +19,7 @@ namespace Microsoft.SemanticKernel
             bool setAsDefault = false
             )
         {
-            model ??= DashScopeModels.QWenV1;
+            model ??= DashScopeModels.QWenTurbo;
             var generation = new DashScopeTextCompletion(apiKey, model, httpClient);
             builder.WithAIService<IChatCompletion>(serviceId, generation, setAsDefault);
 
@@ -30,16 +31,15 @@ namespace Microsoft.SemanticKernel
             return builder;
         }
 
-        public static KernelBuilder WithDashScopeTextEmbeddingGenerationService(
-            this KernelBuilder builder,
+        public static MemoryBuilder WithDashScopeTextEmbeddingGenerationService(
+            this MemoryBuilder builder,
             string apiKey,
             string? model = null,
-            HttpClient? httpClient = null,
-            string? serviceId = null
+            HttpClient? httpClient = null
             )
         {
             model ??= DashScopeModels.TextEmbeddingV1;
-            builder.WithAIService<ITextEmbeddingGeneration>(serviceId, new DashScopeEmbeddingGeneration(apiKey, model, httpClient));
+            builder.WithTextEmbeddingGeneration(new DashScopeEmbeddingGeneration(apiKey, model, httpClient));
 
             return builder;
         }

--- a/src/DashScope.SemanticKernel/DashScopeTextCompletion.cs
+++ b/src/DashScope.SemanticKernel/DashScopeTextCompletion.cs
@@ -125,20 +125,17 @@ namespace DashScope.SemanticKernel
             {
                 return new CompletionParameters();
             }
-            else
+
+            return new CompletionParameters()
             {
-                var parameters = new CompletionParameters()
-                {
-                    TopP = settings.TopP
-                };
-                
-                if (settings.Temperature != null)
-                {
-                    parameters.TopK = Math.Max((int)(settings.Temperature * 100 % 100), 1);
-                }
-                
-                return parameters;
-            }
+                TopP = settings.TopP,
+                Temperature = settings.Temperature,
+                TopK = settings.TopK,
+                Seed = settings.Seed,
+                IncrementalOutput = settings.IncrementalOutput,
+                EnableSearch = settings.EnableSearch,
+                ResultFormat = settings.ResultFormat
+            };
         }
 
         private List<Message> ChatHistoryToMessages(ChatHistory chatHistory)

--- a/src/DashScope.SemanticKernel/DashScopeTextCompletion.cs
+++ b/src/DashScope.SemanticKernel/DashScopeTextCompletion.cs
@@ -12,7 +12,7 @@ namespace DashScope.SemanticKernel
         private readonly string _model;
         private readonly DashScopeClient _client;
 
-        public DashScopeTextCompletion(string apiKey, string model = DashScopeModels.QWenV1, HttpClient? client = null)
+        public DashScopeTextCompletion(string apiKey, string model = DashScopeModels.QWenTurbo, HttpClient? client = null)
         {
             Requires.NotNullOrWhiteSpace(apiKey, nameof(apiKey));
             Requires.NotNullOrWhiteSpace(model, nameof(model));
@@ -40,7 +40,7 @@ namespace DashScope.SemanticKernel
         public async Task<IReadOnlyList<IChatResult>> GetChatCompletionsAsync(ChatHistory chat, AIRequestSettings? requestSettings = null, CancellationToken cancellationToken = default)
         {
             var settings = DashScopeAIRequestSettings.FromRequestSettings(requestSettings);
-            
+
             var response = await _client.GenerationAsync(new CompletionRequest()
             {
                 Input = {
@@ -56,7 +56,7 @@ namespace DashScope.SemanticKernel
         public async Task<IReadOnlyList<ITextResult>> GetCompletionsAsync(string text, AIRequestSettings? requestSettings, CancellationToken cancellationToken = default)
         {
             var settings = DashScopeAIRequestSettings.FromRequestSettings(requestSettings);
-            
+
             var response = await _client.GenerationAsync(new CompletionRequest()
             {
                 Input = {
@@ -79,17 +79,17 @@ namespace DashScope.SemanticKernel
         public async IAsyncEnumerable<IChatStreamingResult> GetStreamingChatCompletionsAsync(ChatHistory chat, AIRequestSettings? requestSettings = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             var settings = DashScopeAIRequestSettings.FromRequestSettings(requestSettings);
-            
+
             var responses = _client.GenerationStreamAsync(new CompletionRequest()
             {
                 Input =
                 {
                     Messages = ChatHistoryToMessages(chat),
                 },
-                Parameters = ToParameters(settings),
+                Parameters = ToParameters(settings, true),
                 Model = this._model
             }, cancellationToken);
-            
+
             yield return new DashScopeChatResult(responses);
             await Task.CompletedTask;
         }
@@ -97,7 +97,7 @@ namespace DashScope.SemanticKernel
         public async IAsyncEnumerable<ITextStreamingResult> GetStreamingCompletionsAsync(string text, AIRequestSettings? requestSettings, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             var settings = DashScopeAIRequestSettings.FromRequestSettings(requestSettings);
-            
+
             var responses = _client.GenerationStreamAsync(new CompletionRequest()
             {
                 Input =
@@ -111,15 +111,15 @@ namespace DashScope.SemanticKernel
                         }
                     }
                 },
-                Parameters = ToParameters(settings),
+                Parameters = ToParameters(settings, true),
                 Model = this._model
             }, cancellationToken);
-            
+
             yield return new DashScopeChatResult(responses);
             await Task.CompletedTask;
         }
 
-        private static CompletionParameters ToParameters(DashScopeAIRequestSettings? settings)
+        private static CompletionParameters ToParameters(DashScopeAIRequestSettings? settings, bool? stream = null)
         {
             if (settings == null)
             {
@@ -132,9 +132,9 @@ namespace DashScope.SemanticKernel
                 Temperature = settings.Temperature,
                 TopK = settings.TopK,
                 Seed = settings.Seed,
-                IncrementalOutput = settings.IncrementalOutput,
+                IncrementalOutput = stream,
                 EnableSearch = settings.EnableSearch,
-                ResultFormat = settings.ResultFormat
+                ResultFormat = "text"
             };
         }
 

--- a/src/DashScope/DashScopeClient.cs
+++ b/src/DashScope/DashScopeClient.cs
@@ -42,7 +42,7 @@ namespace DashScope
             }
             else
             {
-                throw new DashScopeException(result.StatusCode, result.Message);
+                throw new DashScopeException(result.Code, result.Message);
             }
         }
 
@@ -95,7 +95,7 @@ namespace DashScope
             }
             else
             {
-                throw new DashScopeException(result.StatusCode, result.Message);
+                throw new DashScopeException(result.Code, result.Message);
             }
         }
 

--- a/src/DashScope/DashScopeClient.cs
+++ b/src/DashScope/DashScopeClient.cs
@@ -50,9 +50,9 @@ namespace DashScope
         {
             var response = await RequestAsync(request, true, cancellationToken: cancellationToken);
 
-            using var stream = await response.Content.ReadAsStreamAsync();
+            await using var stream = await response.Content.ReadAsStreamAsync();
             using var reader = new StreamReader(stream);
-            var lastTextIndex = -1;
+            
             while (!reader.EndOfStream)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -63,8 +63,6 @@ namespace DashScope
                 {
                     var data = RemovePrefix(line, "data:");
                     var result = JsonSerializer.Deserialize<CompletionResponse>(data)!;
-                    result.Output.Text = result.Output.Text.Substring(lastTextIndex + 1);
-                    lastTextIndex += result.Output.Text.Length;
                     yield return result;
                 }
             }

--- a/src/DashScope/DashScopeClient.cs
+++ b/src/DashScope/DashScopeClient.cs
@@ -52,7 +52,7 @@ namespace DashScope
 
             await using var stream = await response.Content.ReadAsStreamAsync();
             using var reader = new StreamReader(stream);
-            
+
             while (!reader.EndOfStream)
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/DashScope/DashScopeException.cs
+++ b/src/DashScope/DashScopeException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Runtime.Serialization;
 
 namespace DashScope
@@ -6,18 +7,24 @@ namespace DashScope
     [Serializable]
     public class DashScopeException : Exception
     {
-        public int Code { get; set; } = -1;
+        public string Code { get; set; } = string.Empty;
 
         public DashScopeException(string message) : base(message)
         {
         }
-        public DashScopeException(int code, string message) : base(message)
+
+        public DashScopeException(string code, string message) : base(message)
         {
             this.Code = code;
         }
 
         public DashScopeException(string message, Exception innerException) : base(message, innerException)
         {
+        }
+
+        public DashScopeException(string code, string message, Exception innerException) : base(message, innerException)
+        {
+            this.Code = code;
         }
 
         protected DashScopeException(SerializationInfo info, StreamingContext context) : base(info, context)

--- a/src/DashScope/DashScopeModels.cs
+++ b/src/DashScope/DashScopeModels.cs
@@ -9,15 +9,35 @@ namespace DashScope
         /// <summary>
         /// 通义千问超大规模语言模型，支持中文英文等不同语言输入。
         /// </summary>
+        [Obsolete]
         public const string QWenV1 = "qwen-v1";
         /// <summary>
         /// 通义千问超大规模语言模型增强版，支持中文英文等不同语言输入。
         /// </summary>
+        [Obsolete]
         public const string QWenPlusV1 = "qwen-plus-v1";
+
+        /// <summary>
+        /// 通义千问超大规模语言模型，支持中文英文等不同语言输入。
+        /// 模型支持 8k tokens上下文，为了保障正常使用和正常输出，API限定用户输入为6k Tokens。
+        /// </summary>
+        public const string QWenTurbo = "qwen-turbo";
+
+        /// <summary>
+        /// 通义千问超大规模语言模型增强版，支持中文英文等不同语言输入。
+        /// 模型支持 8k tokens上下文，为了保障正常使用和正常输出，API限定用户输入为6k Tokens。
+        /// </summary>
+        public const string QWenPlus = "qwen-plus";
+
 
         /// <summary>
         /// 通用文本向量,支持中文、英语、西班牙语、法语、葡萄牙语、印尼语。
         /// </summary>
         public const string TextEmbeddingV1 = "text-embedding-v1";
+
+        /// <summary>
+        /// 通用文本向量批处理,支持中文、英语、西班牙语、法语、葡萄牙语、印尼语。
+        /// </summary>
+        public const string TextEmbeddingAsyncV1 = "text-embedding-async-v1";
     }
 }

--- a/src/DashScope/Models/CompletionRequest.cs
+++ b/src/DashScope/Models/CompletionRequest.cs
@@ -8,7 +8,7 @@ namespace DashScope.Models
     public class CompletionRequest
     {
         [JsonPropertyName("model")]
-        public string Model { get; set; } = DashScopeModels.QWenV1;
+        public string Model { get; set; } = DashScopeModels.QWenTurbo;
 
         [JsonPropertyName("input")]
         public CompletionInput Input { get; set; } = new();

--- a/src/DashScope/Models/CompletionRequest.cs
+++ b/src/DashScope/Models/CompletionRequest.cs
@@ -32,36 +32,58 @@ namespace DashScope.Models
     public class CompletionParameters
     {
         /// <summary>
-        /// 生成时，核采样方法的概率阈值。例如，取值为0.8时，仅保留累计概率之和大于等于0.8的概率分布中的token，作为随机采样的候选集。取值范围为(0,1.0)，取值越大，生成的随机性越高；取值越低，生成的随机性越低。默认值 0.8。注意，取值不要大于等于1
+        /// 生成时，核采样方法的概率阈值。例如，取值为0.5时，仅保留累计概率之和大于等于0.5的概率分布中的token，作为随机采样的候选集。取值范围为(0,1.0)，取值越大，生成的随机性越高；取值越低，生成的随机性越低。默认值 0.5。注意，取值不要大于等于1
         /// </summary>
         [JsonPropertyName("top_p")]
-        public float? TopP { get; set; } = 0.8f;
+        public float? TopP { get; set; } = 0.5f;
 
         /// <summary>
-        /// 生成时，采样候选集的大小。例如，取值为50时，仅将单次生成中得分最高的50个token组成随机采样的候选集。取值越大，生成的随机性越高；取值越小，生成的确定性越高。注意：如果top_k的值大于100，top_k将采用默认值100
+        /// 默认值为null，表示不启用top_k策略，取值范围：[1, 100]，生成时，采样候选集的大小。例如，取值为50时，仅将单次生成中得分最高的50个token组成随机采样的候选集。取值越大，生成的随机性越高；取值越小，生成的确定性越高。注意：如果top_k的值大于100，则不会启用top_k策略，此时仅有top_p策略生效。
         /// </summary>
         [JsonPropertyName("top_k")]
         public int? TopK { get; set; }
 
         /// <summary>
-        /// 生成时，随机数的种子，用于控制模型生成的随机性。如果使用相同的种子，每次运行生成的结果都将相同；当需要复现模型的生成结果时，可以使用相同的种子。
+        /// 生成时，随机数的种子，用于控制模型生成的随机性。如果使用相同的种子，每次运行生成的结果都将相同；当需要复现模型的生成结果时，可以使用相同的种子。seed参数支持无符号64位整数类型。默认值 1234
         /// </summary>
         [JsonPropertyName("seed")]
-        public long? Seed { get; set; }
+        public long? Seed { get; set; } = 1234;
 
         /// <summary>
-        /// 生成时，是否参考夸克搜索的结果。
+        /// 生成时，是否参考夸克搜索的结果。注意：打开搜索并不意味着一定会使用搜索结果；如果打开搜索，模型会将搜索结果作为prompt，进而“自行判断”是否生成结合搜索结果的文本，默认为false
         /// </summary>
         [JsonPropertyName("enable_search")]
         public bool? EnableSearch { get; set; } = false;
-        /// <summary>
-        /// 接口输入和输出的信息是否通过绿网过滤，默认不调用绿网。
-        /// </summary>
-        [JsonIgnore]
-        public bool? DataInspection { get; set; }
 
+        /// <summary>
+        /// "text"表示旧版本的text，"message"表示兼容openai的message
+        /// </summary>
         [JsonPropertyName("result_format")]
-        public string? ResultFormat { get; set; } = "text";
+        public string? ResultFormat { get; set; }
+
+        /// <summary>
+        ///用于控制随机性和多样性的程度。具体来说，temperature值控制了生成文本时对每个候选词的概率分布进行平滑的程度。较高的temperature值会降低概率分布的峰值，使得更多的低概率词被选择，生成结果更加多样化；而较低的temperature值则会增强概率分布的峰值，使得高概率词更容易被选择，生成结果更加确定。取值范围： (0, 2),系统默认值1.0
+        /// </summary>
+        [JsonPropertyName("temperature")]
+        public float? Temperature { get; set; } = 1.0f;
+
+        /// <summary>
+        /// 控制流式输出模式，默认False，即后面内容会包含已经输出的内容；设置为True，将开启增量输出模式，后面输出不会包含已经输出的内容，您需要自行拼接整体输出
+        /// <example> 流式输出示例代码
+        /// <code>
+        /// 值为False时:
+        /// I
+        /// I like
+        /// I like apple
+        /// 值为True时:
+        /// I
+        /// like
+        /// apple
+        /// </code>
+        /// </example>
+        /// </summary>
+        [JsonPropertyName("incremental_output")]
+        public bool? IncrementalOutput { get; set; } = false;
     }
 
     public class Message

--- a/src/DashScope/Models/CompletionResponse.cs
+++ b/src/DashScope/Models/CompletionResponse.cs
@@ -19,7 +19,7 @@ namespace DashScope.Models
     {
         [JsonPropertyName("total_tokens")]
         public int TotalTokens { get; set; }
-        
+
         [JsonPropertyName("input_tokens")]
         public int InputTokens { get; set; }
 
@@ -31,38 +31,23 @@ namespace DashScope.Models
     {
         [JsonPropertyName("finish_reason")]
         public string? FinishReason { get; set; }
-        
+
         [JsonPropertyName("text")]
         public string? Text { get; set; }
-        
+
         [JsonPropertyName("choices")]
         public List<Choice>? Choices { get; set; }
 
         public bool IsTextOutput => Choices == null;
     }
-    public class CompletionTextOutput
-    {
-        [JsonPropertyName("finish_reason")]
-        public string FinishReason { get; set; } = string.Empty;
-        
-        [JsonPropertyName("text")]
-        public string Text { get; set; } = string.Empty;
-    }
-    
-    public class CompletionMessageOutput
-    {
-        [JsonPropertyName("choices")]
-        public List<Choice> Choices { get; set; } = new List<Choice>();
-    }
 
-    
     public class Choice
     {
         [JsonPropertyName("finish_reason")]
-        public string FinishReason { get; set; } = string.Empty;
+        public string? FinishReason { get; set; }
 
-        [JsonPropertyName("message")] 
+        [JsonPropertyName("message")]
         public Message Message { get; set; } = new Message();
     }
-    
+
 }

--- a/src/DashScope/Models/CompletionResponse.cs
+++ b/src/DashScope/Models/CompletionResponse.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace DashScope.Models
 {
@@ -10,19 +11,15 @@ namespace DashScope.Models
         [JsonPropertyName("usage")]
         public CompletionUsage Usage { get; set; } = new CompletionUsage();
 
-        [JsonPropertyName("finish_reason")]
-        public string FinishReason { get; set; } = string.Empty;
-    }
+        public bool IsTextResponse => Output.IsTextOutput;
 
-
-    public class CompletionOutput
-    {
-        [JsonPropertyName("text")]
-        public string Text { get; set; } = string.Empty;
     }
 
     public class CompletionUsage
     {
+        [JsonPropertyName("total_tokens")]
+        public int TotalTokens { get; set; }
+        
         [JsonPropertyName("input_tokens")]
         public int InputTokens { get; set; }
 
@@ -30,6 +27,42 @@ namespace DashScope.Models
         public int OutputTokens { get; set; }
     }
 
+    public class CompletionOutput
+    {
+        [JsonPropertyName("finish_reason")]
+        public string? FinishReason { get; set; }
+        
+        [JsonPropertyName("text")]
+        public string? Text { get; set; }
+        
+        [JsonPropertyName("choices")]
+        public List<Choice>? Choices { get; set; }
 
+        public bool IsTextOutput => Choices == null;
+    }
+    public class CompletionTextOutput
+    {
+        [JsonPropertyName("finish_reason")]
+        public string FinishReason { get; set; } = string.Empty;
+        
+        [JsonPropertyName("text")]
+        public string Text { get; set; } = string.Empty;
+    }
+    
+    public class CompletionMessageOutput
+    {
+        [JsonPropertyName("choices")]
+        public List<Choice> Choices { get; set; } = new List<Choice>();
+    }
 
+    
+    public class Choice
+    {
+        [JsonPropertyName("finish_reason")]
+        public string FinishReason { get; set; } = string.Empty;
+
+        [JsonPropertyName("message")] 
+        public Message Message { get; set; } = new Message();
+    }
+    
 }

--- a/src/DashScope/Models/DashScopeResponse.cs
+++ b/src/DashScope/Models/DashScopeResponse.cs
@@ -11,7 +11,7 @@ namespace DashScope.Models
         [JsonPropertyName("status_code")]
         public int StatusCode { get; set; }
 
-        [JsonPropertyName("request_Id")]
+        [JsonPropertyName("request_id")]
         public string RequestId { get; set; } = string.Empty;
 
         [JsonPropertyName("code")]

--- a/src/DashScope/Models/DashScopeResponse.cs
+++ b/src/DashScope/Models/DashScopeResponse.cs
@@ -8,9 +8,6 @@ namespace DashScope.Models
 
     public class DashScopeResponse
     {
-        [JsonPropertyName("status_code")]
-        public int StatusCode { get; set; }
-
         [JsonPropertyName("request_id")]
         public string RequestId { get; set; } = string.Empty;
 


### PR DESCRIPTION
1. ChatRequestSettings，CompleteRequestSettings 已经被弃用且删除，新版统一改用 AIRequestSettings
2. AIException 已弃用且删除， 新版改用 SKException 和 HttpOperationException
详见https://github.com/microsoft/semantic-kernel/issues/1669
part8 与 part9
3. 将 AIRequestSettings 封装成 DashScopeAIRequestSettings
4. 修改 CompletionRequest，使其参数与通义千问文档完全对应
5. 完善 DashScopeAIRequestSettings 的参数，使其参数与通义千问文档完全对应
6. 添加使用 DashScopeAIRequestSettings 的示例代码
7. 添加 stream 模式的 TextCompletion 的示例代码
8. 改正 DashScopeResponse.RequestId 的 JsonPropertyName 特性中的拼写错误
9. 移除 DashScopeResponse 中的 StatusCode，因为接口已经不会返回 status_code 了
10. 支持类型为 message 的 result_format，并为其添加示例代码