### PR TITLE
🔀 Update package versions and add metadata to chat messages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,15 +5,15 @@
   <ItemGroup>
     <!--Unit Test-->
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.KernelMemory.Abstractions" Version="0.23.231219.1" />
-    <PackageVersion Include="Microsoft.KernelMemory.Core" Version="0.23.231219.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.0.1" />
+    <PackageVersion Include="Microsoft.KernelMemory.Abstractions" Version="0.27.240205.2" />
+    <PackageVersion Include="Microsoft.KernelMemory.Core" Version="0.27.240205.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0-preview-24080-01" />
+    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.3.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.8.8" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.0" />
-    <PackageVersion Include="xunit" Version="2.6.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.5" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.1" />
+    <PackageVersion Include="xunit" Version="2.6.6" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/samples/SK-DashScope.Sample/Controllers/ApiController.cs
+++ b/samples/SK-DashScope.Sample/Controllers/ApiController.cs
@@ -127,5 +127,28 @@ namespace SK_DashScope.Sample.Controllers
 
             await Response.CompleteAsync();
         }
+
+        [HttpPost("semantic")]
+        public async Task<IActionResult> SemanticAsync([FromBody] UserInput input, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(input.Text))
+            {
+                return NoContent();
+            }
+
+            var prompt =
+                """
+				翻译以下内容为英文：
+
+				{{$input}}
+				
+				""";
+            var result = await kernel.InvokePromptAsync(prompt, new KernelArguments() { ["input"] = input.Text }, cancellationToken: cancellationToken);
+            var value = result.GetValue<string>();
+            var usage = result.Metadata?["Usage"];
+
+            return Ok(new { value, usage });
+
+        }
     }
 }

--- a/src/DashScope.SemanticKernel/DashScopeChatResult.cs
+++ b/src/DashScope.SemanticKernel/DashScopeChatResult.cs
@@ -6,14 +6,16 @@ namespace DashScope.SemanticKernel
 {
     public class DashScopeChatMessage : ChatMessageContent
     {
-        public DashScopeChatMessage(CompletionResponse response) : base(AuthorRole.Assistant, response.Output.Text!)
+        public DashScopeChatMessage(CompletionResponse response, IReadOnlyDictionary<string, object?>? metadata = null)
+            : base(AuthorRole.Assistant, response.Output.Text!, metadata: metadata)
         {
 
         }
     }
     public class DashScopeStreamingChatMessage : StreamingChatMessageContent
     {
-        public DashScopeStreamingChatMessage(CompletionResponse response) : base(AuthorRole.Assistant, response.Output.Text!, response)
+        public DashScopeStreamingChatMessage(CompletionResponse response, IReadOnlyDictionary<string, object?>? metadata = null)
+            : base(AuthorRole.Assistant, response.Output.Text!, response, metadata: metadata)
         {
 
         }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<PackageId>$(AssemblyName)</PackageId>
-		<Version>0.7.0</Version>
+		<Version>0.8.0</Version>
 		<LangVersion>12</LangVersion>
 		<Nullable>enable</Nullable>
 		<Authors>Custouch</Authors>


### PR DESCRIPTION
- Update package versions for Microsoft.KernelMemory.Abstractions, Microsoft.KernelMemory.Core, Microsoft.NET.Test.Sdk, Microsoft.SemanticKernel, System.Text.Json, xunit, and xunit.runner.visualstudio
- Add metadata parameter to DashScopeChatMessage and DashScopeStreamingChatMessage constructors
- Add metadata parameter to DashScopeTextCompletion constructors
- Add GetResponseMetadata method to retrieve response metadata
- Update DashScopeTextCompletion.GetStreamingTextContentsAsync and DashScopeTextCompletion.GetStreamingChatMessageContentsAsync to include metadata in the returned content
- Update DashScopeTextCompletion.GetTextContentsAsync and DashScopeTextCompletion.GetChatMessageContentsAsync to include metadata in the returned content
- Add ChatHistoryToMessages method to convert ChatHistory to a list of Messages
- Update Directory.Build.props version to 0.8.0